### PR TITLE
Fixed support for network of Realsense cameras

### DIFF
--- a/multi_camera_tracking/open_ptrack_config/detection/launch/realsense_frames.launch
+++ b/multi_camera_tracking/open_ptrack_config/detection/launch/realsense_frames.launch
@@ -5,5 +5,5 @@
   <arg name="pi/2" value="1.5707963267948966" />
   <arg name="pi" value="3.14159265359" />
   <arg name="optical_rotate" value="0 0 0 $(arg pi/2) -$(arg pi/2) 0" />
-  <node pkg="tf" type="static_transform_publisher" name="link1_broadcaster" args="$(arg optical_rotate) $(arg camera) $(arg camera)_link 100" />                 
+  <node pkg="tf" type="static_transform_publisher" name="$(arg camera)_link_broadcaster" args="$(arg optical_rotate) $(arg camera) $(arg camera)_link 100" />                 
 </launch>

--- a/multi_camera_tracking/open_ptrack_config/detection/launch/skeleton_detector_realsense.launch
+++ b/multi_camera_tracking/open_ptrack_config/detection/launch/skeleton_detector_realsense.launch
@@ -29,7 +29,7 @@
       <param name="caffe_proto" value="$(find rtpose_wrapper)/model/mpi/pose_deploy_linevec.prototxt"
       unless="$(arg use_coco)"/>
 
-    <param name="depth_topic"                   value="/$(arg sensor_name)/depth/image_rect_raw"/>
+    <param name="depth_topic"                value="/$(arg sensor_name)/aligned_depth_to_color/image_raw"/>
     <param name="rgb_topic"                  value="/$(arg sensor_name)/color/image_rect_color"/>
     <param name="camera_info_topic"          value="/$(arg sensor_name)/color/camera_info" />
 

--- a/single_camera_tracking/open_ptrack_config/detection/launch/skeleton_detector_realsense.launch
+++ b/single_camera_tracking/open_ptrack_config/detection/launch/skeleton_detector_realsense.launch
@@ -29,7 +29,7 @@
       <param name="caffe_proto" value="$(find rtpose_wrapper)/model/mpi/pose_deploy_linevec.prototxt"
       unless="$(arg use_coco)"/>
 
-    <param name="depth_topic"                   value="/$(arg sensor_name)/depth/image_rect_raw"/>
+    <param name="depth_topic"                value="/$(arg sensor_name)/aligned_depth_to_color/image_raw"/>
     <param name="rgb_topic"                  value="/$(arg sensor_name)/color/image_rect_color"/>
     <param name="camera_info_topic"          value="/$(arg sensor_name)/color/camera_info" />
 


### PR DESCRIPTION
The name for the transform publisher was hard-coded as "link1_broadcaster", which prevented from using a network of multiple Realsense cameras. Fixed by including the camera argument in the broadcaster name .